### PR TITLE
상단 navbar 고정

### DIFF
--- a/todo/post/templates/post/index.html
+++ b/todo/post/templates/post/index.html
@@ -23,10 +23,10 @@
         .button-group > button {
             vertical-align: middle;
         }
-        .button-group > button {
+        .btn-toggle {
             display: none;
         }
-        .button-group > .btn-add {
+        .btn-add {
             display: block;
         }
         .list-group-item > div {
@@ -67,13 +67,13 @@
 
 <div class="container">
     <div class="button-group">
-        <button type="button" class="btn btn-warning btn-add">추가</button>
-        <button type="button" class="btn btn-warning btn-post">생성</button>
-        <button type="button" class="btn btn-default btn-cancel">취소</button>
-        <button type="button" class="btn btn-info btn-detail" data-toggle="modal" data-target="#myModal">상세</button>
-        <button type="button" class="btn btn-default btn-lift">상승</button>
-        <button type="button" class="btn btn-default btn-fall">하강</button>
-        <button type="button" class="btn btn-danger btn-finish">완료</button>
+        <button type="button" class="btn btn-warning btn-add btn-toggle">추가</button>
+        <button type="button" class="btn btn-warning btn-post btn-toggle">생성</button>
+        <button type="button" class="btn btn-default btn-cancel btn-toggle">취소</button>
+        <button type="button" class="btn btn-info btn-detail btn-toggle" data-toggle="modal" data-target="#myModal">상세</button>
+        <button type="button" class="btn btn-default btn-lift btn-toggle">상승</button>
+        <button type="button" class="btn btn-default btn-fall btn-toggle">하강</button>
+        <button type="button" class="btn btn-danger btn-finish btn-toggle">완료</button>
     </div>
     <form action="" method="post" id="task-form">
         {% csrf_token %}
@@ -112,19 +112,19 @@
                     if ($(this).hasClass("list-group-item-warning")) {
                         // 나를 선택 해제하고, 버튼들도 끈다.
                         $(this).toggleClass("list-group-item-warning", false);
-                        $(".button-group > button").hide();
-                        $(".button-group > .btn-add").show();
+                        $(".btn-toggle").hide();
+                        $(".btn-add").show();
                     } else {
                         // 모든 버튼들을 선택 해제하고, 나를 선택하고, 버튼들을 켠다.
                         removeListGroupItemWarningClass();
                         $(this).toggleClass("list-group-item-warning", true);
-                        $(".button-group > .btn-detail").show();
-                        $(".button-group > .btn-lift").show();
-                        $(".button-group > .btn-fall").show();
-                        $(".button-group > .btn-finish").show();
-                        $(".button-group > .btn-add").hide();
-                        $(".button-group > .btn-post").hide();
-                        $(".button-group > .btn-cancel").hide();
+                        $(".btn-detail").show();
+                        $(".btn-lift").show();
+                        $(".btn-fall").show();
+                        $(".btn-finish").show();
+                        $(".btn-add").hide();
+                        $(".btn-post").hide();
+                        $(".btn-cancel").hide();
                         $("#task-form").slideUp();
                     }
                 }
@@ -135,8 +135,8 @@
         $("body").click(function(e){
            if(e.target == this) {
                removeListGroupItemWarningClass();
-               $(".button-group > button").hide();
-               $(".button-group > .btn-add").show();
+               $(".btn-toggle").hide();
+               $(".btn-add").show();
            }
         });
 

--- a/todo/post/templates/post/index.html
+++ b/todo/post/templates/post/index.html
@@ -11,6 +11,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <style>
+        body {
+            padding-top: 70px;
+        }
         #task-form {
             display: none;
         }
@@ -53,7 +56,7 @@
     </div>
 </div>
 
-<nav class="navbar navbar-default">
+<nav class="navbar navbar-default navbar-fixed-top">
     <div class="container-fluid">
         <div class="navbar-header">
             <a class="navbar-brand" href="{% url 'post:index' %}">TODO</a>

--- a/todo/post/templates/post/index.html
+++ b/todo/post/templates/post/index.html
@@ -98,34 +98,20 @@
 </div>
 
 <script>
-    function removeListGroupItemWarningClass() {
-        $(".list-group-item").each(function() {
-            $(this).toggleClass("list-group-item-warning", false);
-        })
-    }
-
     $('document').ready(function(){
         // list-group-item 들의 click event
         $(".list-group-item").each(function(){
             $(this).click(function(e){
                 if (e.target == this) {
                     if ($(this).hasClass("list-group-item-warning")) {
-                        // 나를 선택 해제하고, 버튼들도 끈다.
+                        // 나를 선택 해제하고, nav-bar의 버튼들을 끈다.
                         $(this).toggleClass("list-group-item-warning", false);
-                        $(".btn-toggle").hide();
-                        $(".btn-add").show();
+                        $("nav .btn-toggle").hide();
                     } else {
-                        // 모든 버튼들을 선택 해제하고, 나를 선택하고, 버튼들을 켠다.
-                        removeListGroupItemWarningClass();
+                        // 기존에 선택된 item을 해제하고, 나를 선택하고, navbar의 버튼들을 켠다.
+                        $(".list-group-item-warning").toggleClass("list-group-item-warning");
                         $(this).toggleClass("list-group-item-warning", true);
-                        $(".btn-detail").show();
-                        $(".btn-lift").show();
-                        $(".btn-fall").show();
-                        $(".btn-finish").show();
-                        $(".btn-add").hide();
-                        $(".btn-post").hide();
-                        $(".btn-cancel").hide();
-                        $("#task-form").slideUp();
+                        $("nav .btn-toggle").show();
                     }
                 }
             });
@@ -134,7 +120,7 @@
         // body 빈공간의 click event
         $("body").click(function(e){
            if(e.target == this) {
-               removeListGroupItemWarningClass();
+               $(".list-group-item-warning").toggleClass("list-group-item-warning");
                $(".btn-toggle").hide();
                $(".btn-add").show();
            }

--- a/todo/post/templates/post/index.html
+++ b/todo/post/templates/post/index.html
@@ -62,6 +62,10 @@
             <a class="navbar-brand" href="{% url 'post:index' %}">TODO</a>
         </div>
         <button type="button" class="btn btn-default navbar-btn" onclick="location.href='{% url 'logout' %}?next={% url 'post:index' %}'">로그아웃</button>
+        <button type="button" class="btn btn-info btn-detail btn-toggle" data-toggle="modal" data-target="#myModal">상세</button>
+        <button type="button" class="btn btn-default btn-lift btn-toggle">상승</button>
+        <button type="button" class="btn btn-default btn-fall btn-toggle">하강</button>
+        <button type="button" class="btn btn-danger btn-finish btn-toggle">완료</button>
     </div>
 </nav>
 
@@ -70,10 +74,6 @@
         <button type="button" class="btn btn-warning btn-add btn-toggle">추가</button>
         <button type="button" class="btn btn-warning btn-post btn-toggle">생성</button>
         <button type="button" class="btn btn-default btn-cancel btn-toggle">취소</button>
-        <button type="button" class="btn btn-info btn-detail btn-toggle" data-toggle="modal" data-target="#myModal">상세</button>
-        <button type="button" class="btn btn-default btn-lift btn-toggle">상승</button>
-        <button type="button" class="btn btn-default btn-fall btn-toggle">하강</button>
-        <button type="button" class="btn btn-danger btn-finish btn-toggle">완료</button>
     </div>
     <form action="" method="post" id="task-form">
         {% csrf_token %}


### PR DESCRIPTION
### navbar 고정

**Bootstrap** 클래스를 추가하고, 고정된 **navbar** 에 가리지 않도록 `body`에 `padding-top`을 준다.
### 버튼 정리

스크롤을 아래로 내린 후에 선택된 Task에 대해서도 상세/상승/하강/완료 버튼을 누를 수 있어야 한다. 그러므로 이 4개의 버튼들을 **navbar** 로 옮긴다.
